### PR TITLE
Change tagFormat for Golang submodules

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -2,5 +2,5 @@ import { tagFormat } from "../src"
 
 // Jest doesn't honor require.cache, so it's impossible to test this stuff
 test("tagFormat", () => {
-  expect(tagFormat).toMatch(/^semantic-release-commit-filter-v\$\{version\}$/u)
+  expect(tagFormat).toMatch(/^pkg\/semantic-release-commit-filter\/v\$\{version\}$/u)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,6 @@ Object.keys(require.cache)
     }
   })
 
-export const tagFormat = `${
+export const tagFormat = `pkg/${
   require(posix.resolve(process.cwd(), "package.json")).name
-}-v\${version}`
+}/v\${version}`


### PR DESCRIPTION
This pull request changes `tagFormat` to make `semantic-release` work for Golang submodules with a more or less standardised `/pkg/<gomodule-name>` pattern.

Submodules released under such tags, can be easily specified and used further in `go.mod`.